### PR TITLE
Fix leaks of Image objects in TesseractOcrUtil

### DIFF
--- a/itext.tests/itext.pdfocr.tesseract4.tests/itext.pdfocr.tesseract4.tests.csproj
+++ b/itext.tests/itext.pdfocr.tesseract4.tests/itext.pdfocr.tesseract4.tests.csproj
@@ -9,7 +9,7 @@
     <OutputType>library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/itext.tests/itext.pdfocr.tesseract4.tests/itext/pdfocr/general/BasicTesseractIntegrationTest.cs
+++ b/itext.tests/itext.pdfocr.tesseract4.tests/itext/pdfocr/general/BasicTesseractIntegrationTest.cs
@@ -284,6 +284,62 @@ namespace iText.Pdfocr.General {
             }
         }
 
+        [NUnit.Framework.Test]
+        public virtual void TestTiffIsDisposed() {
+            String testName = "testTiffIsDisposed";
+            String path = TEST_IMAGES_DIRECTORY + "numbers_01.tif";
+            String tmpPath = System.IO.Path.GetTempFileName();
+            String pdfPath = GetTargetDirectory() + testName + ".pdf";
+            FileInfo file = new FileInfo(tmpPath);
+            File.Copy(path, tmpPath, true);
+            OcrPdfCreator ocrPdfCreator = new OcrPdfCreator(tesseractReader);
+            NUnit.Framework.Assert.IsTrue(System.GC.TryStartNoGCRegion(8*1024*1024));
+            PdfDocument doc = ocrPdfCreator.CreatePdf(JavaCollectionsUtil.SingletonList<FileInfo>(file), GetPdfWriter(
+                pdfPath));
+            File.Delete(tmpPath);
+            System.GC.EndNoGCRegion();
+            NUnit.Framework.Assert.IsNotNull(doc);
+            doc.Close();
+        }
+
+        [NUnit.Framework.Test]
+        public virtual void TestTiffIsDisposedWithoutPreprocessing() {
+            String testName = "testTiffIsDisposedWithoutPreprocessing";
+            String path = TEST_IMAGES_DIRECTORY + "numbers_01.tif";
+            String tmpPath = System.IO.Path.GetTempFileName();
+            String pdfPath = GetTargetDirectory() + testName + ".pdf";
+            FileInfo file = new FileInfo(tmpPath);
+            File.Copy(path, tmpPath, true);
+            tesseractReader.SetTesseract4OcrEngineProperties(tesseractReader.GetTesseract4OcrEngineProperties().SetPreprocessingImages
+                (false));
+            OcrPdfCreator ocrPdfCreator = new OcrPdfCreator(tesseractReader);
+            NUnit.Framework.Assert.IsTrue(System.GC.TryStartNoGCRegion(8 * 1024 * 1024));
+            PdfDocument doc = ocrPdfCreator.CreatePdf(JavaCollectionsUtil.SingletonList<FileInfo>(file), GetPdfWriter(
+                pdfPath));
+            File.Delete(tmpPath);
+            System.GC.EndNoGCRegion();
+            NUnit.Framework.Assert.IsNotNull(doc);
+            doc.Close();
+        }
+
+        [NUnit.Framework.Test]
+        public virtual void TestJpegIsDisposed() {
+            String testName = "testJpegIsDisposed";
+            String path = TEST_IMAGES_DIRECTORY + "numbers_01.jpg";
+            String tmpPath = System.IO.Path.GetTempFileName();
+            String pdfPath = GetTargetDirectory() + testName + ".pdf";
+            FileInfo file = new FileInfo(tmpPath);
+            File.Copy(path, tmpPath, true);
+            OcrPdfCreator ocrPdfCreator = new OcrPdfCreator(tesseractReader);
+            NUnit.Framework.Assert.IsTrue(System.GC.TryStartNoGCRegion(8 * 1024 * 1024));
+            PdfDocument doc = ocrPdfCreator.CreatePdf(JavaCollectionsUtil.SingletonList<FileInfo>(file), GetPdfWriter(
+                pdfPath));
+            File.Delete(tmpPath);
+            System.GC.EndNoGCRegion();
+            NUnit.Framework.Assert.IsNotNull(doc);
+            doc.Close();
+        }
+
         /// <summary>Parse text from image and compare with expected.</summary>
         private void TestImageOcrText(AbstractTesseract4OcrEngine tesseractReader, String path, String expectedOutput
             ) {

--- a/itext/itext.pdfocr.tesseract4/itext/pdfocr/tesseract4/TesseractOcrUtil.cs
+++ b/itext/itext.pdfocr.tesseract4/itext/pdfocr/tesseract4/TesseractOcrUtil.cs
@@ -472,6 +472,7 @@ namespace iText.Pdfocr.Tesseract4 {
                     temp.SetResolution(2 * xResolution, 2 * yResolution);
                     bitmapList.Add(temp);
                 }
+                originalImage.Dispose();
                 SetListOfPages(bitmapList);
             } catch (Exception e)
             {
@@ -514,6 +515,7 @@ namespace iText.Pdfocr.Tesseract4 {
                 }
                 image.SelectActiveFrame(FrameDimension.Page, page);
                 img = new Bitmap(image);
+                image.Dispose();
             } catch (Exception e)
             {
                 LogManager.GetLogger(typeof(TesseractOcrUtil))
@@ -889,8 +891,8 @@ namespace iText.Pdfocr.Tesseract4 {
         {
             try
             {
-                System.Drawing.Image image = System.Drawing.Image.FromFile(inputFile.FullName);
-                return ReadRotationFromMetadata(image);
+                using (System.Drawing.Image image = System.Drawing.Image.FromFile(inputFile.FullName))
+                    return ReadRotationFromMetadata(image);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Those leaks made it impossible to delete the input files
until after GC.